### PR TITLE
Menubar fix

### DIFF
--- a/visuol/src/Menu.js
+++ b/visuol/src/Menu.js
@@ -47,7 +47,7 @@ class SideMenu extends Component {
                 Register
             </NavLink>
         </Menu.Item>
-        <Menu.Item key="3">
+        <Menu.Item key="new-offer">
             <NavLink to="/new-offer">
                 New Offer
             </NavLink>

--- a/visuol/yarn.lock
+++ b/visuol/yarn.lock
@@ -3244,9 +3244,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
-  version "1.0.30001191"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz#bacb432b6701f690c8c5f7c680166b9a9f0843d9"
-  integrity sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==
+  version "1.0.30001271"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
+  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixed the menubar bug where reloading a page would always default the selection to the first option. Now, we base the default option on the URL of the page we're on.

Closes #54.